### PR TITLE
feat: Explicit error with unsupported files

### DIFF
--- a/src/duckdb_read_stat.c
+++ b/src/duckdb_read_stat.c
@@ -173,9 +173,9 @@ void duckdb_read_stat_bind(duckdb_bind_info info)
             data->file_format = DUCKDB_READ_STAT_FILE_FORMAT_STATA;
             error = readstat_parse_dta(parser, path, data);
         }
-        else if (!strcmp(format, "sas7cdat"))
+        else if (!strcmp(format, "sas7bcat"))
         {
-            duckdb_bind_set_error(info, "SAS catalog files (.sas7cdat) are not supported. Only SAS data files (.sas7bdat, .xpt) are supported.");
+            duckdb_bind_set_error(info, "SAS catalog files (.sas7bcat) are not supported. Only SAS data files (.sas7bdat, .xpt) are supported.");
             readstat_parser_free(parser);
             duckdb_free(data);
             return;
@@ -213,9 +213,9 @@ void duckdb_read_stat_bind(duckdb_bind_info info)
         data->file_format = DUCKDB_READ_STAT_FILE_FORMAT_STATA;
         error = readstat_parse_dta(parser, path, data);
     }
-    else if (duckdb_read_stat_ends_with(path, ".sas7cdat"))
+    else if (duckdb_read_stat_ends_with(path, ".sas7bcat"))
     {
-        duckdb_bind_set_error(info, "SAS catalog files (.sas7cdat) are not supported. Only SAS data files (.sas7bdat, .xpt) are supported.");
+        duckdb_bind_set_error(info, "SAS catalog files (.sas7bcat) are not supported. Only SAS data files (.sas7bdat, .xpt) are supported.");
         readstat_parser_free(parser);
         duckdb_free(data);
         return;

--- a/src/duckdb_read_stat.c
+++ b/src/duckdb_read_stat.c
@@ -153,7 +153,7 @@ void duckdb_read_stat_bind(duckdb_bind_info info)
             data->file_format = DUCKDB_READ_STAT_FILE_FORMAT_SAS;
             error = readstat_parse_sas7bdat(parser, path, data);
         }
-        if (!strcmp(format, "xpt"))
+        else if (!strcmp(format, "xpt"))
         {
             data->file_format = DUCKDB_READ_STAT_FILE_FORMAT_SAS;
             error = readstat_parse_xport(parser, path, data);
@@ -172,6 +172,20 @@ void duckdb_read_stat_bind(duckdb_bind_info info)
         {
             data->file_format = DUCKDB_READ_STAT_FILE_FORMAT_STATA;
             error = readstat_parse_dta(parser, path, data);
+        }
+        else if (!strcmp(format, "sas7cdat"))
+        {
+            duckdb_bind_set_error(info, "SAS catalog files (.sas7cdat) are not supported. Only SAS data files (.sas7bdat, .xpt) are supported.");
+            readstat_parser_free(parser);
+            duckdb_free(data);
+            return;
+        }
+        else
+        {
+            duckdb_bind_set_error(info, "Unsupported format parameter. Supported formats are: sas7bdat, xpt (SAS), sav, zsav, por (SPSS), and dta (Stata).");
+            readstat_parser_free(parser);
+            duckdb_free(data);
+            return;
         }
     }
     else if (duckdb_read_stat_ends_with(path, ".sas7bdat"))
@@ -198,6 +212,20 @@ void duckdb_read_stat_bind(duckdb_bind_info info)
     {
         data->file_format = DUCKDB_READ_STAT_FILE_FORMAT_STATA;
         error = readstat_parse_dta(parser, path, data);
+    }
+    else if (duckdb_read_stat_ends_with(path, ".sas7cdat"))
+    {
+        duckdb_bind_set_error(info, "SAS catalog files (.sas7cdat) are not supported. Only SAS data files (.sas7bdat, .xpt) are supported.");
+        readstat_parser_free(parser);
+        duckdb_free(data);
+        return;
+    }
+    else
+    {
+        duckdb_bind_set_error(info, "Unsupported file extension. Supported formats are: .sas7bdat, .xpt (SAS), .sav, .zsav, .por (SPSS), and .dta (Stata). Specify the format parameter explicitly if the file extension is incorrect.");
+        readstat_parser_free(parser);
+        duckdb_free(data);
+        return;
     }
 
     if (error != READSTAT_OK)


### PR DESCRIPTION
For #5.

When I try to run tests, I see:

```
✗ make test_debug
Running DEBUG tests..
/Users/kirill/git/duckdb-read-stat/configure/venv/bin/python3: No module named duckdb_sqllogictest.__main__; 'duckdb_sqllogictest' is a package and cannot be directly executed
make: *** [test_extension_debug_internal] Error 1
```

Happy to add tests once I understand how to run them, perhaps also on CI/CD?